### PR TITLE
Added missing headers in var libAMPI_a_HEADERS for correct make install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 CC=@MPICC@
-AM_CXXFLAGS = -I$(srcdir)/include  
+AM_CXXFLAGS = -I$(srcdir)/include
 AM_CFLAGS   = -I$(srcdir)/include $(OPENMP_FLAGS) @MPI_FLAGS@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
 
@@ -8,17 +8,18 @@ lib_LIBRARIES = libAMPI.a
 libAMPI_adir = $(includedir)
 
 libAMPI_a_HEADERS=\
-                  include/ampi.h include/ampi_stack.h \
-		   \
-		  include/ampi_interface.h include/ampi_tape.hpp 
+                  include/ampi.h \
+                  include/ampi_interface.h \
+                  include/ampi_interface.hpp \
+                  include/ampi_stack.h \
+                  include/ampi_tape.h \
+                  include/ampi_tape.hpp
 
 libAMPI_a_SOURCES = \
                     $(libAMPI_a_HEADERS) \
-                    src/ampi.c src/ampi_stack.c \
-		    src/ampi_tape.c \
-                    include/ampi.h include/ampi_stack.h \
-		    \
-		    include/ampi_interface.h include/ampi_tape.hpp 
+                    src/ampi.c \
+                    src/ampi_stack.c \
+                    src/ampi_tape.c
 
 AUTOMAKE_OPTIONS = subdir-objects
 


### PR DESCRIPTION
**Problem**
- When executing "make install" certain headers (ampi_interface.hpp and ampi_tape.h) are not copied over to the folder "$prefix/include"

**Solution**
Modified Makefile.am:
- Explicitly added all headers in folder "$root/include" to the variable "libAMPI_a_HEADERS"
- Removed the explicit header paths usage of variable "libAMPI_a_SOURCES "
